### PR TITLE
Fix pointer underflow in Utils::rstrstr

### DIFF
--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -37,9 +37,12 @@ char *Utils::rstrstr (const char *a, const char *b) {
   if (b_len > a_len)
     return nullptr;
 
-  for (const char *s = a + a_len - b_len; s >= a; --s) {
+  for (const char *s = a + a_len - b_len; s >= a;) {
     if (!strncmp(s, b, b_len))
       return const_cast<char *>(s);
+    if (s == a)
+      break;
+    --s;
   }
 
   return nullptr;


### PR DESCRIPTION
## Summary
- fix pointer underflow in `Utils::rstrstr`

## Testing
- `tools/check_qml_syntax` *(fails: Unable to find qmllint)*
- `tools/test_qml` *(fails: qmltestrunner: command not found)*